### PR TITLE
Add 'circleCIMode' option to include file attribute in each <testsuite> tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ output line 2
 | antMode                        | `false`                | set to truthy value to return xml compatible with [Ant JUnit schema][ant-schema]                                        |
 | antHostname                    | `process.env.HOSTNAME` | hostname to use when running in `antMode`  will default to environment `HOSTNAME`                                       |
 | jenkinsMode                    | `false`                | if set to truthy value will return xml that will display nice results in Jenkins                                        |
+| circleCIMode                   | `false`                | if set to truthy value will return xml that will append a file attribute to each test suite for Circle CI               |
 
 [travis-badge]: https://travis-ci.org/michaelleeallen/mocha-junit-reporter.svg?branch=master
 [travis-build]: https://travis-ci.org/michaelleeallen/mocha-junit-reporter

--- a/index.js
+++ b/index.js
@@ -420,6 +420,8 @@ MochaJUnitReporter.prototype.getXml = function(testsuites) {
   var hasProperties = (!!this._options.properties) || antMode;
   var Date = this._Date;
 
+  var suiteFileName = testsuites[0].testsuite[0]._attr.file;
+
   testsuites.forEach(function(suite) {
     var _suiteAttr = suite.testsuite[0]._attr;
     // testsuite is an array: [attrs, properties?, testcase, testcase, …]
@@ -435,6 +437,7 @@ MochaJUnitReporter.prototype.getXml = function(testsuites) {
     _suiteAttr.timestamp = new Date(_suiteAttr.timestamp).toISOString().slice(0, -5);
     _suiteAttr.failures = 0;
     _suiteAttr.skipped = 0;
+    _suiteAttr.file = suiteFileName;
 
     _cases.forEach(function(testcase) {
       var lastNode = testcase.testcase[testcase.testcase.length - 1];

--- a/index.js
+++ b/index.js
@@ -67,6 +67,7 @@ function configureDefaults(options) {
   config.attachments = getSetting(config.attachments, 'ATTACHMENTS', false);
   config.antMode = getSetting(config.antMode, 'ANT_MODE', false);
   config.jenkinsMode = getSetting(config.jenkinsMode, 'JENKINS_MODE', false);
+  config.circleCIMode = getSetting(config.circleCIMode, 'CIRCLE_CI_MODE', false);
   config.properties = getSetting(config.properties, 'PROPERTIES', null, parsePropertiesFromEnv);
   config.toConsole = !!config.toConsole;
   config.rootSuiteTitle = config.rootSuiteTitle || 'Root Suite';
@@ -416,11 +417,12 @@ MochaJUnitReporter.prototype.flush = function(testsuites){
 MochaJUnitReporter.prototype.getXml = function(testsuites) {
   var totalTests = 0;
   var stats = this._runner.stats;
+  var circleCIMode = this._options.circleCIMode;
   var antMode = this._options.antMode;
   var hasProperties = (!!this._options.properties) || antMode;
   var Date = this._Date;
 
-  var suiteFileName = testsuites[0].testsuite[0]._attr.file;
+  var suiteFileName = testsuites[0] && testsuites[0].testsuite[0] && testsuites[0].testsuite[0]._attr && testsuites[0].testsuite[0]._attr.file;
 
   testsuites.forEach(function(suite) {
     var _suiteAttr = suite.testsuite[0]._attr;
@@ -437,7 +439,10 @@ MochaJUnitReporter.prototype.getXml = function(testsuites) {
     _suiteAttr.timestamp = new Date(_suiteAttr.timestamp).toISOString().slice(0, -5);
     _suiteAttr.failures = 0;
     _suiteAttr.skipped = 0;
-    _suiteAttr.file = suiteFileName;
+
+    if (circleCIMode) {
+      _suiteAttr.file = suiteFileName;
+    }
 
     _cases.forEach(function(testcase) {
       var lastNode = testcase.testcase[testcase.testcase.length - 1];

--- a/test/mocha-junit-reporter-spec.js
+++ b/test/mocha-junit-reporter-spec.js
@@ -77,6 +77,7 @@ describe('mocha-junit-reporter', function() {
 
     var runner = reporter.runner;
     var rootSuite = runner.suite;
+    rootSuite.file = "spec.js";
 
     var suite1 = Suite.create(rootSuite, options.title);
     suite1.addTest(createTest('can weez the juice', {

--- a/test/mocha-junit-reporter-spec.js
+++ b/test/mocha-junit-reporter-spec.js
@@ -715,6 +715,29 @@ describe('mocha-junit-reporter', function() {
       });
     });
 
+    it('generates Circle CI compatible XML when in circleCIMode', function(done) {
+      this.timeout(10000); // xmllint is very slow
+
+      var reporter = createReporter({circleCIMode: true});
+      var rootSuite = reporter.runner.suite;
+
+      var suite1 = Suite.create(rootSuite, 'Inner Suite');
+      suite1.addTest(createTest('test'));
+
+      var suite2 = Suite.create(rootSuite, 'Another Suite');
+      suite2.addTest(createTest('test', function(done) {
+        done(new Error('failed test'));
+      }));
+
+      runRunner(reporter.runner, function() {
+        var schema = fs.readFileSync(path.join(__dirname, 'resources', 'circle-ci-junit.xsd'));
+        var result = xmllint.validateXML({ xml: reporter._xml, schema: schema });
+        expect(result.errors).to.equal(null, JSON.stringify(result.errors));
+
+        done();
+      });
+    });
+
     it('generates Ant compatible XML when in antMode', function(done) {
       this.timeout(10000); // xmllint is very slow
 

--- a/test/mock-results.js
+++ b/test/mock-results.js
@@ -35,7 +35,6 @@ module.exports = function(stats, options) {
               timestamp: "1970-01-01T00:00:00",
               tests: "3",
               failures: "2",
-              file: "spec.js",
               time: "100.001"
             }
           },
@@ -98,7 +97,6 @@ module.exports = function(stats, options) {
               timestamp: "1970-01-01T00:01:40", // new Date(100001).toISOString().slice(0, -5)
               tests: "1",
               failures: "0",
-              file: "spec.js",
               time: "400.005"
             }
           },

--- a/test/mock-results.js
+++ b/test/mock-results.js
@@ -21,6 +21,7 @@ module.exports = function(stats, options) {
               timestamp: "1970-01-01T00:00:00", // ISO timestamp truncated to the second
               tests: "0",
               failures: "0",
+              file: "spec.js",
               time: "0.000"
             }
           }
@@ -34,6 +35,7 @@ module.exports = function(stats, options) {
               timestamp: "1970-01-01T00:00:00",
               tests: "3",
               failures: "2",
+              file: "spec.js",
               time: "100.001"
             }
           },
@@ -96,6 +98,7 @@ module.exports = function(stats, options) {
               timestamp: "1970-01-01T00:01:40", // new Date(100001).toISOString().slice(0, -5)
               tests: "1",
               failures: "0",
+              file: "spec.js",
               time: "400.005"
             }
           },

--- a/test/resources/circle-ci-junit.xsd
+++ b/test/resources/circle-ci-junit.xsd
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+ Source: https://svn.jenkins-ci.org/trunk/hudson/dtkit/dtkit-format/dtkit-junit-model/src/main/resources/com/thalesgroup/dtkit/junit/model/xsd/junit-4.xsd
+
+ This file available under the terms of the the MIT License as follows:
+
+ *******************************************************************************
+ * Copyright (c) 2010 Thales Corporate Services SAS                             *
+ *                                                                              *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy *
+ * of this software and associated documentation files (the "Software"), to deal*
+ * in the Software without restriction, including without limitation the rights *
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell    *
+ * copies of the Software, and to permit persons to whom the Software is        *
+ * furnished to do so, subject to the following conditions:                     *
+ *                                                                              *
+ * The above copyright notice and this permission notice shall be included in   *
+ * all copies or substantial portions of the Software.                          *
+ *                                                                              *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR   *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE  *
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER       *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,*
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN    *
+ * THE SOFTWARE.                                                                *
+ ********************************************************************************
+ -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+    <xs:element name="failure">
+        <xs:complexType mixed="true">
+            <xs:attribute name="type" type="xs:string" use="optional"/>
+            <xs:attribute name="message" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="error">
+        <xs:complexType mixed="true">
+            <xs:attribute name="type" type="xs:string" use="optional"/>
+            <xs:attribute name="message" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="properties">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="property" maxOccurs="unbounded"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="property">
+        <xs:complexType>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="value" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="skipped" type="xs:string"/>
+    <xs:element name="system-err" type="xs:string"/>
+    <xs:element name="system-out" type="xs:string"/>
+
+    <xs:element name="testcase">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="skipped" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="error" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="failure" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="system-out" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="system-err" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="assertions" type="xs:string" use="optional"/>
+            <xs:attribute name="time" type="xs:string" use="optional"/>
+            <xs:attribute name="classname" type="xs:string" use="optional"/>
+            <xs:attribute name="status" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="testsuite">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="properties" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="testcase" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="system-out" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="system-err" minOccurs="0" maxOccurs="1"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="tests" type="xs:string" use="required"/>
+            <xs:attribute name="failures" type="xs:string" use="optional"/>
+            <xs:attribute name="errors" type="xs:string" use="optional"/>
+            <xs:attribute name="time" type="xs:string" use="optional"/>
+            <xs:attribute name="disabled" type="xs:string" use="optional"/>
+            <xs:attribute name="skipped" type="xs:string" use="optional"/>
+            <xs:attribute name="timestamp" type="xs:string" use="optional"/>
+            <xs:attribute name="hostname" type="xs:string" use="optional"/>
+            <xs:attribute name="id" type="xs:string" use="optional"/>
+            <xs:attribute name="package" type="xs:string" use="optional"/>
+            <xs:attribute name="file" type="xs:string" use="required"/> <!-- Circle CI's test functionality requires each suite to have a file attribute -->
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="testsuites">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="testsuite" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="optional"/>
+            <xs:attribute name="time" type="xs:string" use="optional"/>
+            <xs:attribute name="tests" type="xs:string" use="optional"/>
+            <xs:attribute name="failures" type="xs:string" use="optional"/>
+            <xs:attribute name="disabled" type="xs:string" use="optional"/>
+            <xs:attribute name="errors" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+
+</xs:schema>


### PR DESCRIPTION
Enables Circle CI to ingest test results and display a filename for each failing test.

```bash
 ~/src/mocha-junit-reporter   jp/extended-properties  npm test

> mocha-junit-reporter@2.0.2 test
> MOCHA_FILE=test/mocha.xml node_modules/.bin/mocha test --reporter=spec



  mocha-junit-reporter
    ✔ can produce a JUnit XML report
    ✔ respects `process.env.MOCHA_FILE`
    ✔ respects `process.env.PROPERTIES`
    ✔ respects `--reporter-options mochaFile=`
    ✔ respects `[hash]` pattern in test results report filename
    ✔ will create intermediate directories
    ✔ creates valid XML report for invalid message
    ✔ creates valid XML report even if title contains ANSI character sequences
    ✔ outputs pending tests if "includePending" is specified
    ✔ properly outputs tests when error in beforeAll
    ✔ properly diffs errors from Chai
    when "useFullSuiteTitle" option is specified
      ✔ generates full suite title
      ✔ generates full suite title separated by "suiteTitleSeparatedBy" option
    when "outputs" option is specified
      ✔ adds output/error lines to xml report
      ✔ does not add system-out if no outputs/errors were passed
      ✔ does not add system-out if outputs/errors were empty
    when "attachments" option is specified
      ✔ adds attachments to xml report
      ✔ does not add system-out if no attachments were passed
      ✔ does not add system-out if attachments array is empty
      ✔ includes both console outputs and attachments in XML
    Output
      ✔ skips suites with empty title
      ✔ skips suites without testcases and suites
      ✔ skips suites without testcases even if they have nested suites
      ✔ does not skip suites with nested tests
      ✔ does not skip root suite
      ✔ respects the `rootSuiteTitle`
      ✔ uses "Mocha Tests" by default
      ✔ respects the `testsuitesTitle`
    Feature "Configurable classname/name switch"
      ✔ should generate valid testCase for testCaseSwitchClassnameAndName default
      ✔ should generate valid testCase for testCaseSwitchClassnameAndName=false
      ✔ should generate valid testCase for testCaseSwitchClassnameAndName=true
    XML format

      ✔ generates Jenkins compatible XML when in jenkinsMode (741ms)

      ✔ generates Circle CI compatible XML when in circleCIMode

      ✔ generates Ant compatible XML when in antMode (130ms)
      Jenkins format
        ✔ generates Jenkins compatible classnames and suite name


  36 passing (991ms)
```