### PR TITLE
Extract #tags and @team mentions from test names and configuration, and include them in the output

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,8 @@ output line 2
 | antMode                        | `false`                | set to truthy value to return xml compatible with [Ant JUnit schema][ant-schema]                                        |
 | antHostname                    | `process.env.HOSTNAME` | hostname to use when running in `antMode`  will default to environment `HOSTNAME`                                       |
 | jenkinsMode                    | `false`                | if set to truthy value will return xml that will display nice results in Jenkins                                        |
-| circleCIMode                   | `false`                | if set to truthy value will append a file attribute to each test suite for Circle CI               |
+| circleCIMode                   | `false`                | if set to truthy value will append a file attribute to each test suite for Circle CI                                    |
+| includeTags                    | `false`                | if set to truthy value, includes tags extracted from the test name and any custom tags provided via Cypress             |
 
 [travis-badge]: https://travis-ci.org/michaelleeallen/mocha-junit-reporter.svg?branch=master
 [travis-build]: https://travis-ci.org/michaelleeallen/mocha-junit-reporter

--- a/index.js
+++ b/index.js
@@ -68,6 +68,7 @@ function configureDefaults(options) {
   config.antMode = getSetting(config.antMode, 'ANT_MODE', false);
   config.jenkinsMode = getSetting(config.jenkinsMode, 'JENKINS_MODE', false);
   config.circleCIMode = getSetting(config.circleCIMode, 'CIRCLE_CI_MODE', false);
+  config.includeTags = getSetting(config.includeTags, 'INCLUDE_TAGS', false);
   config.properties = getSetting(config.properties, 'PROPERTIES', null, parsePropertiesFromEnv);
   config.toConsole = !!config.toConsole;
   config.rootSuiteTitle = config.rootSuiteTitle || 'Root Suite';
@@ -320,16 +321,62 @@ MochaJUnitReporter.prototype.getTestsuiteData = function(suite) {
  */
 MochaJUnitReporter.prototype.getTestcaseData = function(test, err) {
   var jenkinsMode = this._options.jenkinsMode;
+  var includeTags = this._options.includeTags;
   var flipClassAndName = this._options.testCaseSwitchClassnameAndName;
   var name = stripAnsi(jenkinsMode ? getJenkinsClassname(test, this._options) : test.fullTitle());
   var classname = stripAnsi(test.title);
+
+  var properties = {
+    name: flipClassAndName ? classname : name,
+    time: (typeof test.duration === 'undefined') ? 0 : test.duration / 1000,
+    classname: flipClassAndName ? name : classname
+  };
+
+  if (includeTags) {
+    // extract tags and teams from the test name
+    // this regex matches any whole word beginning with # or @
+    // includes words surrounded by parenthesis, square brackets, and punctuation
+    var tagsFromName = name.match(/([#|@]\w+)/g) || [];
+
+     // inspect the supplied test object to see if it has any user-created properties
+    // this object will be present if the tests were run by Cypress, and if any additional
+    // key/value pairs were added to the test.
+    var customProperties = test && test._testConfig && test._testConfig.unverifiedTestConfig || {};
+    var tagPropertyValue = customProperties['tags'];
+
+    var tagsFromProperties = [];
+
+    // the 'tags' property can contain tags in a comma separated string, or in an array
+    // figure out which format is used, and ensure we end up with an array
+    if (tagPropertyValue !== undefined) {
+      if (Array.isArray(tagPropertyValue)) {
+        tagsFromProperties = tagPropertyValue;
+      } else if (typeof tagPropertyValue === 'string' || tagPropertyValue instanceof String) {
+        tagsFromProperties = tagPropertyValue.split(',');
+      } else {
+        console.warn('the "tags" custom property value for test "' + name + '" was neither an array nor a string (actual: ' + tagPropertyValue + '), and was ignored. this probably means that the test metadata isn\'t working the way it was intended.');
+      }
+    }
+
+    // combine the tags from both sources, trim spaces from the beginning and end,
+    // and deduplicate them
+    var allTags = tagsFromName.concat(tagsFromProperties);
+    var trimmedAndDedupedTags = [];
+
+    for (var i = 0; i < allTags.length; i++) {
+      var cleaned = allTags[i].trim();
+
+      if (trimmedAndDedupedTags.indexOf(cleaned) === -1) {
+        trimmedAndDedupedTags.push(cleaned);
+      }
+    }
+
+    properties = Object.assign({}, properties, { tags: trimmedAndDedupedTags });
+  }
+
   var testcase = {
     testcase: [{
-      _attr: {
-        name: flipClassAndName ? classname : name,
-        time: (typeof test.duration === 'undefined') ? 0 : test.duration / 1000,
-        classname: flipClassAndName ? name : classname
-      }
+      _attr: properties,
     }]
   };
 

--- a/test/resources/tagged-junit.xsd
+++ b/test/resources/tagged-junit.xsd
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+ Source: https://svn.jenkins-ci.org/trunk/hudson/dtkit/dtkit-format/dtkit-junit-model/src/main/resources/com/thalesgroup/dtkit/junit/model/xsd/junit-4.xsd
+
+ This file available under the terms of the the MIT License as follows:
+
+ *******************************************************************************
+ * Copyright (c) 2010 Thales Corporate Services SAS                             *
+ *                                                                              *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy *
+ * of this software and associated documentation files (the "Software"), to deal*
+ * in the Software without restriction, including without limitation the rights *
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell    *
+ * copies of the Software, and to permit persons to whom the Software is        *
+ * furnished to do so, subject to the following conditions:                     *
+ *                                                                              *
+ * The above copyright notice and this permission notice shall be included in   *
+ * all copies or substantial portions of the Software.                          *
+ *                                                                              *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR   *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE  *
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER       *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,*
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN    *
+ * THE SOFTWARE.                                                                *
+ ********************************************************************************
+ -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+    <xs:element name="failure">
+        <xs:complexType mixed="true">
+            <xs:attribute name="type" type="xs:string" use="optional"/>
+            <xs:attribute name="message" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="error">
+        <xs:complexType mixed="true">
+            <xs:attribute name="type" type="xs:string" use="optional"/>
+            <xs:attribute name="message" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="properties">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="property" maxOccurs="unbounded"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="property">
+        <xs:complexType>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="value" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="skipped" type="xs:string"/>
+    <xs:element name="system-err" type="xs:string"/>
+    <xs:element name="system-out" type="xs:string"/>
+
+    <xs:element name="testcase">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="skipped" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="error" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="failure" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="system-out" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="system-err" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="assertions" type="xs:string" use="optional"/>
+            <xs:attribute name="time" type="xs:string" use="optional"/>
+            <xs:attribute name="classname" type="xs:string" use="optional"/>
+            <xs:attribute name="status" type="xs:string" use="optional"/>
+            <xs:attribute name="tags" type="xs:string" use="required"/> <!-- tags derived from the name/config when includeTags=true -->
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="testsuite">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="properties" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="testcase" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="system-out" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="system-err" minOccurs="0" maxOccurs="1"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="tests" type="xs:string" use="required"/>
+            <xs:attribute name="failures" type="xs:string" use="optional"/>
+            <xs:attribute name="errors" type="xs:string" use="optional"/>
+            <xs:attribute name="time" type="xs:string" use="optional"/>
+            <xs:attribute name="disabled" type="xs:string" use="optional"/>
+            <xs:attribute name="skipped" type="xs:string" use="optional"/>
+            <xs:attribute name="timestamp" type="xs:string" use="optional"/>
+            <xs:attribute name="hostname" type="xs:string" use="optional"/>
+            <xs:attribute name="id" type="xs:string" use="optional"/>
+            <xs:attribute name="package" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="testsuites">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="testsuite" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="optional"/>
+            <xs:attribute name="time" type="xs:string" use="optional"/>
+            <xs:attribute name="tests" type="xs:string" use="optional"/>
+            <xs:attribute name="failures" type="xs:string" use="optional"/>
+            <xs:attribute name="disabled" type="xs:string" use="optional"/>
+            <xs:attribute name="errors" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+
+</xs:schema>


### PR DESCRIPTION
Tests (`describe` and `it` function calls) can now include `#tags` and `@team` mentions in the name.  For example, the following test:

```js
describe('a test #suite', () => {
  it('has @test cases', () => { });
});
```

Will result in XML output for this test case which includes a `tags` attribute containing the value `#suite,@test`.  Note that tags and teams can be included in the name of both `describe` and `it`, and additional levels of nesting of either will retain tags and teams included in higher levels.  For example:

```js
describe('@one', () => {
  describe('@two', () => {
    describe('@three', () => {
      it('@four', () => {})
    })
  })
})
```

Would result in a `tags` value of `@one,@two,@three,@four`.

When used with Cypress tests, tags and teams may also be included in the test configuration object passed as the second argument in `describe` and `it`:

```js
describe('a test suite', { tags: ['@suite'] }, () => {
  it('has @test cases', () => { });
});
```

OR

```js
describe('a test @suite', () => {
  it('has test cases', { tags: ['@test'] }, () => { });
});
```

Would result in a `tags` value of `@suite,@test`.  

As with tags included in test names, values specified in configuration are copied to more deeply nested suites and tests, _however_, if a more deeply nested suite or test also defines tags in its configuration, tags and team mentions are overwritten instead of added to the parent configuration.  For example:

```js
describe('a test suite', { tags: ['@suite'] }, () => {
  it('has test cases', { tags: ['@test'] }, () => { });
});
```

Will result in a derived tag value of only `@test`.

This behavior is enabled by passing the `includeTags` option with a truthy value.