### PR TITLE
Source 'tags' from _testConfig within Cypress 8/9

### DIFF
--- a/LICENSE-THIRD-PARTY.txt
+++ b/LICENSE-THIRD-PARTY.txt
@@ -1,0 +1,56 @@
+This project includes two functions, 'getTag' and 'isString', copied from
+the lodash repository (https://github.com/lodash/lodash).
+
+The license for lodash is included below.
+
+----------------------------------------------------------------------------
+
+The MIT License
+
+Copyright JS Foundation and other contributors <https://js.foundation/>
+
+Based on Underscore.js, copyright Jeremy Ashkenas,
+DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+This software consists of voluntary contributions made by many
+individuals. For exact contribution history, see the revision history
+available at https://github.com/lodash/lodash
+
+The following license applies to all parts of this software except as
+documented below:
+
+====
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+====
+
+Copyright and related rights for sample code are waived via CC0. Sample
+code is defined as all source code displayed within the prose of the
+documentation.
+
+CC0: http://creativecommons.org/publicdomain/zero/1.0/
+
+====
+
+Files located in the node_modules and vendor directories are externally
+maintained libraries used by this software which have their own
+licenses; we recommend you read them, as their terms may differ from the
+terms above.

--- a/index.js
+++ b/index.js
@@ -322,9 +322,10 @@ MochaJUnitReporter.prototype.getTestsuiteData = function(suite) {
  */
 function getTagsFromTestcaseData(name, test) {
   // extract tags and teams from the test name
-  // this regex matches any whole word beginning with # or @
+  // this regex matches any whole word beginning with # or @ and containing letters, numbers, - and _
   // includes words surrounded by parenthesis, square brackets, and punctuation
-  var tagsFromName = name.match(/([#|@]\w+)/g) || [];
+  // ex: @foo #bar #qux-quux #under_score (@in_parens) [#in-brackets]
+  var tagsFromName = name.match(/([#|@][\w\-_]+)/g) || [];
 
   // inspect the supplied test object to see if it has any user-created properties
   // this object will be present if the tests were run by Cypress, and if any additional

--- a/index.js
+++ b/index.js
@@ -329,12 +329,12 @@ function getTagsFromTestcaseData(name, test) {
   // inspect the supplied test object to see if it has any user-created properties
   // this object will be present if the tests were run by Cypress, and if any additional
   // key/value pairs were added to the test.
-  var testConfig = test && test._testConfig;
+  var testConfig = test && test._testConfig || {};
 
   var tagPropertyValue = undefined;
 
   // Cypress => ~9.0.0 puts user-defined tags in _testConfig.unverifiedTestConfig.tags
-  if (testConfig && testConfig.unverifiedTestConfig && testConfig.unverifiedTestConfig.tags) {
+  if (testConfig.unverifiedTestConfig && testConfig.unverifiedTestConfig.tags) {
     tagPropertyValue = testConfig.unverifiedTestConfig.tags;
   }
   // Cypress =< ~8.0.0 puts user-defined tags in _testConfig.tags

--- a/index.js
+++ b/index.js
@@ -346,7 +346,7 @@ function getTagsFromTestcaseData(name, test) {
 
   // the 'tags' property can contain tags in a comma separated string, or in an array
   // figure out which format is used, and ensure we end up with an array
-  if (tagPropertyValue !== undefined) {
+  if (tagPropertyValue) {
     if (Array.isArray(tagPropertyValue)) {
       tagsFromProperties = tagPropertyValue;
     } else if (typeof tagPropertyValue === 'string' || tagPropertyValue instanceof String) {

--- a/index.js
+++ b/index.js
@@ -350,7 +350,7 @@ function getTagsFromTestcaseData(name, test) {
   if (tagPropertyValue) {
     if (Array.isArray(tagPropertyValue)) {
       tagsFromProperties = tagPropertyValue;
-    } else if (typeof tagPropertyValue === 'string' || tagPropertyValue instanceof String) {
+    } else if (isString(tagPropertyValue)) {
       tagsFromProperties = tagPropertyValue.split(',');
     } else {
       console.warn('the "tags" custom property value for test "' + name + '" was neither an array nor a string (actual: ' + tagPropertyValue + '), and was ignored. this probably means that the test metadata isn\'t working the way it was intended.');
@@ -584,3 +584,42 @@ MochaJUnitReporter.prototype.writeXmlToDisk = function(xml, filePath){
     debug('results written successfully');
   }
 };
+
+
+/**
+ * [Gets the `toStringTag` of `value`.
+ *
+ * Copied from lodash; see LICENSE-THIRD-PARTY.txt for license.
+ *
+ * @private
+ * @param {*} value The value to query.
+ * @returns {string} Returns the `toStringTag`.
+ */
+ function getTag(value) {
+  if (value == null) {
+    return value === undefined ? '[object Undefined]' : '[object Null]';
+  }
+  return Object.prototype.toString.call(value);
+}
+
+/**
+ * Checks if `value` is classified as a `String` primitive or object.
+ *
+ * Copied from lodash; see LICENSE-THIRD-PARTY.txt for license.
+ *
+ * @since 0.1.0
+ * @category Lang
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is a string, else `false`.
+ * @example
+ *
+ * isString('abc')
+ * // => true
+ *
+ * isString(1)
+ * // => false
+ */
+ function isString(value) {
+  var type = typeof value;
+  return type === 'string' || (type === 'object' && value != null && !Array.isArray(value) && getTag(value) == '[object String]');
+}

--- a/index.js
+++ b/index.js
@@ -314,6 +314,65 @@ MochaJUnitReporter.prototype.getTestsuiteData = function(suite) {
 };
 
 /**
+ * Given a fully qualified test name and test case context, derive a list of user-defined
+ * tags, if present.
+ *
+ * @param {String} name - the fully qualified name of the test
+ * @param {object} test - test case
+ */
+function getTagsFromTestcaseData(name, test) {
+  // extract tags and teams from the test name
+  // this regex matches any whole word beginning with # or @
+  // includes words surrounded by parenthesis, square brackets, and punctuation
+  var tagsFromName = name.match(/([#|@]\w+)/g) || [];
+
+  // inspect the supplied test object to see if it has any user-created properties
+  // this object will be present if the tests were run by Cypress, and if any additional
+  // key/value pairs were added to the test.
+  var testConfig = test && test._testConfig;
+
+  var tagPropertyValue = undefined;
+
+  // Cypress => ~9.0.0 puts user-defined tags in _testConfig.unverifiedTestConfig.tags
+  if (testConfig && testConfig.unverifiedTestConfig && testConfig.unverifiedTestConfig.tags) {
+    tagPropertyValue = testConfig.unverifiedTestConfig.tags;
+  }
+  // Cypress =< ~8.0.0 puts user-defined tags in _testConfig.tags
+  else if (testConfig.tags) {
+    tagPropertyValue = testConfig.tags;
+  }
+
+  var tagsFromProperties = [];
+
+  // the 'tags' property can contain tags in a comma separated string, or in an array
+  // figure out which format is used, and ensure we end up with an array
+  if (tagPropertyValue !== undefined) {
+    if (Array.isArray(tagPropertyValue)) {
+      tagsFromProperties = tagPropertyValue;
+    } else if (typeof tagPropertyValue === 'string' || tagPropertyValue instanceof String) {
+      tagsFromProperties = tagPropertyValue.split(',');
+    } else {
+      console.warn('the "tags" custom property value for test "' + name + '" was neither an array nor a string (actual: ' + tagPropertyValue + '), and was ignored. this probably means that the test metadata isn\'t working the way it was intended.');
+    }
+  }
+
+  // combine the tags from both sources, trim spaces from the beginning and end,
+  // and deduplicate them
+  var allTags = tagsFromName.concat(tagsFromProperties);
+  var trimmedAndDedupedTags = [];
+
+  for (var i = 0; i < allTags.length; i++) {
+    var cleaned = allTags[i].trim();
+
+    if (trimmedAndDedupedTags.indexOf(cleaned) === -1) {
+      trimmedAndDedupedTags.push(cleaned);
+    }
+  }
+
+  return trimmedAndDedupedTags;
+}
+
+/**
  * Produces an xml config for a given test case.
  * @param {object} test - test case
  * @param {object} err - if test failed, the failure object
@@ -333,44 +392,7 @@ MochaJUnitReporter.prototype.getTestcaseData = function(test, err) {
   };
 
   if (includeTags) {
-    // extract tags and teams from the test name
-    // this regex matches any whole word beginning with # or @
-    // includes words surrounded by parenthesis, square brackets, and punctuation
-    var tagsFromName = name.match(/([#|@]\w+)/g) || [];
-
-     // inspect the supplied test object to see if it has any user-created properties
-    // this object will be present if the tests were run by Cypress, and if any additional
-    // key/value pairs were added to the test.
-    var customProperties = test && test._testConfig && test._testConfig.unverifiedTestConfig || {};
-    var tagPropertyValue = customProperties['tags'];
-
-    var tagsFromProperties = [];
-
-    // the 'tags' property can contain tags in a comma separated string, or in an array
-    // figure out which format is used, and ensure we end up with an array
-    if (tagPropertyValue !== undefined) {
-      if (Array.isArray(tagPropertyValue)) {
-        tagsFromProperties = tagPropertyValue;
-      } else if (typeof tagPropertyValue === 'string' || tagPropertyValue instanceof String) {
-        tagsFromProperties = tagPropertyValue.split(',');
-      } else {
-        console.warn('the "tags" custom property value for test "' + name + '" was neither an array nor a string (actual: ' + tagPropertyValue + '), and was ignored. this probably means that the test metadata isn\'t working the way it was intended.');
-      }
-    }
-
-    // combine the tags from both sources, trim spaces from the beginning and end,
-    // and deduplicate them
-    var allTags = tagsFromName.concat(tagsFromProperties);
-    var trimmedAndDedupedTags = [];
-
-    for (var i = 0; i < allTags.length; i++) {
-      var cleaned = allTags[i].trim();
-
-      if (trimmedAndDedupedTags.indexOf(cleaned) === -1) {
-        trimmedAndDedupedTags.push(cleaned);
-      }
-    }
-
+    var trimmedAndDedupedTags = getTagsFromTestcaseData(name, test);
     properties = Object.assign({}, properties, { tags: trimmedAndDedupedTags });
   }
 

--- a/test/mocha-junit-reporter-spec.js
+++ b/test/mocha-junit-reporter-spec.js
@@ -64,12 +64,7 @@ describe('mocha-junit-reporter', function() {
     }
 
     // simulate an injection of test configuration options from Cypress
-    // note that Cypress puts any properties it doesn't know about into
-    // unverifiedTestConfig; the rest go elsewhere.  this is effective
-    // for testing add-on properties ONLY.
-    test._testConfig = {
-      unverifiedTestConfig: options._testConfig
-    };
+    test._testConfig = options._testConfig;
 
     return test;
   }
@@ -614,6 +609,29 @@ describe('mocha-junit-reporter', function() {
 
         expect(reporter._testsuites[1].testsuite[1].testcase[0]._attr.tags).to.have.lengthOf(2);
         expect(reporter._testsuites[1].testsuite[1].testcase[0]._attr.tags).to.have.members(['#tag', '@team']);
+
+        done();
+      });
+    });
+
+    it('does not blow up if _testConfig is missing or malformed', function(done) {
+      var reporter = createReporter({includeTags: true});
+      var rootSuite = reporter.runner.suite;
+      var suite1 = Suite.create(rootSuite, 'root suite has no tag');
+
+      suite1.addTest(createTest('does this blow up', { _testConfig: null }));
+      suite1.addTest(createTest('what about this', { _testConfig: undefined }));
+      suite1.addTest(createTest('how about no tags', { _testConfig: {} }));
+      suite1.addTest(createTest('what if testconfig is a string', { _testConfig: 'a' }));
+      suite1.addTest(createTest('what if tags is an integer', { _testConfig: { tags: 1 } }));
+      suite1.addTest(createTest('what if there is no config', { }));
+
+      runRunner(reporter.runner, function() {
+        if (reporter.runner.dispose) {
+          reporter.runner.dispose();
+        }
+
+        expect(reporter._testsuites[1].testsuite[1].testcase[0]._attr.tags).to.have.lengthOf(0);
 
         done();
       });

--- a/test/mocha-junit-reporter-spec.js
+++ b/test/mocha-junit-reporter-spec.js
@@ -576,6 +576,25 @@ describe('mocha-junit-reporter', function() {
       });
     });
 
+    it('includes tags and teams containing dashes and underscores from the suite and test names', function(done) {
+      var reporter = createReporter({includeTags: true});
+      var rootSuite = reporter.runner.suite;
+      var suite1 = Suite.create(rootSuite, 'root suite');
+
+      suite1.addTest(createTest('test case has #tag-dash and @team_underscore'));
+
+      runRunner(reporter.runner, function() {
+        if (reporter.runner.dispose) {
+          reporter.runner.dispose();
+        }
+
+        expect(reporter._testsuites[1].testsuite[1].testcase[0]._attr.tags).to.have.lengthOf(2);
+        expect(reporter._testsuites[1].testsuite[1].testcase[0]._attr.tags).to.have.members(['#tag-dash', '@team_underscore']);
+
+        done();
+      });
+    });
+
     it('includes tags and teams from the test config when using Cypress >= ~9.0.0 style _testConfig', function(done) {
       var reporter = createReporter({includeTags: true});
       var rootSuite = reporter.runner.suite;

--- a/test/mocha-junit-reporter-spec.js
+++ b/test/mocha-junit-reporter-spec.js
@@ -581,7 +581,26 @@ describe('mocha-junit-reporter', function() {
       });
     });
 
-    it('includes tags and teams from the test config', function(done) {
+    it('includes tags and teams from the test config when using Cypress >= ~9.0.0 style _testConfig', function(done) {
+      var reporter = createReporter({includeTags: true});
+      var rootSuite = reporter.runner.suite;
+      var suite1 = Suite.create(rootSuite, 'root suite has no tag');
+
+      suite1.addTest(createTest('test case includes tags from config', { _testConfig: { unverifiedTestConfig: { tags: ['#tag', '@team']} } }));
+
+      runRunner(reporter.runner, function() {
+        if (reporter.runner.dispose) {
+          reporter.runner.dispose();
+        }
+
+        expect(reporter._testsuites[1].testsuite[1].testcase[0]._attr.tags).to.have.lengthOf(2);
+        expect(reporter._testsuites[1].testsuite[1].testcase[0]._attr.tags).to.have.members(['#tag', '@team']);
+
+        done();
+      });
+    });
+
+    it('includes tags and teams from the test config when using Cypress <= ~8.0.0 style _testConfig', function(done) {
       var reporter = createReporter({includeTags: true});
       var rootSuite = reporter.runner.suite;
       var suite1 = Suite.create(rootSuite, 'root suite has no tag');


### PR DESCRIPTION
We're using Cypress ~8 in Lattice, and this library was designed around Cypress ~9, not knowing there were differences under the hood.  

This PR updates the logic to source user defined tags from both `_testConfig.tags` (Cypress 8) and `_testConfig.unverifiedTestConfig.tags` (Cypress 9).